### PR TITLE
Support local Ollama server in embedding function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     src/ChromaDB/Embeddings/CohereEmbeddingFunction.cpp
     src/ChromaDB/Embeddings/VoyageAIEmbeddingFunction.cpp
     src/ChromaDB/Embeddings/TogetherAIEmbeddingFunction.cpp
+    src/ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.cpp
     src/ChromaDB/Exceptions/ChromaException.cpp
 )
 

--- a/include/ChromaDB/ChromaDB.h
+++ b/include/ChromaDB/ChromaDB.h
@@ -62,3 +62,4 @@
 #include "ChromaDB/Embeddings/CohereEmbeddingFunction.h"
 #include "ChromaDB/Embeddings/VoyageAIEmbeddingFunction.h"
 #include "ChromaDB/Embeddings/TogetherAIEmbeddingFunction.h"
+#include "ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.h"

--- a/include/ChromaDB/Embeddings/EmbeddingFunction.h
+++ b/include/ChromaDB/Embeddings/EmbeddingFunction.h
@@ -29,7 +29,7 @@ namespace chromadb {
 
         nlohmann::json m_LastRequestAdditionalMetadata;
     protected:
-        nlohmann::json Request(const nlohmann::json& body);
+        virtual nlohmann::json Request(const nlohmann::json& body);
     };
 
 } // namespace chromadb

--- a/include/ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.h
+++ b/include/ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "ChromaDB/Embeddings/EmbeddingFunction.h"
+
+namespace chromadb {
+
+class LocalOllamaEmbeddingFunction : public EmbeddingFunction {
+ public:
+  /*
+   * @brief Construct a new LocalOllamaEmbeddingFunction object
+   *
+   * @param address The local Ollama server address
+   * @param model The model to use (optional)
+   */
+  LocalOllamaEmbeddingFunction(const std::string& address = "localhost:11434",
+                               const std::string& model = "deepseek-r1:14b");
+
+  /*
+   * @brief Generate the embeddings of the documents
+   *
+   * @param documents The documents to generate the embeddings
+   *
+   * @return std::vector<std::vector<double>> The embeddings of the documents
+   *
+   * @throw ChromaException if something goes wrong
+   */
+  std::vector<std::vector<double>> Generate(
+      const std::vector<std::string>& documents);
+
+ protected:
+  nlohmann::json Request(const nlohmann::json& body);
+};
+
+}  // namespace chromadb

--- a/src/ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.cpp
+++ b/src/ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.cpp
@@ -1,0 +1,45 @@
+#include "ChromaDB/Embeddings/LocalOllamaEmbeddingFunction.h"
+
+namespace chromadb {
+LocalOllamaEmbeddingFunction::LocalOllamaEmbeddingFunction(
+    const std::string& address, const std::string& model)
+    : EmbeddingFunction("", model, address, "/api/embed") {}
+
+std::vector<std::vector<double>> LocalOllamaEmbeddingFunction::Generate(
+    const std::vector<std::string>& documents) {
+  nlohmann::json body = {{"input", documents}, {"model", m_Model}};
+
+  nlohmann::json response = this->Request(body);
+
+  std::vector<std::vector<double>> embeddings;
+  for (const auto& obj : response["embeddings"]) {
+    embeddings.emplace_back(obj.get<std::vector<double>>());
+  }
+
+  nlohmann::json additionalData;
+  additionalData["model"] = response["model"];
+  m_LastRequestAdditionalMetadata = additionalData;
+
+  return embeddings;
+}
+
+nlohmann::json LocalOllamaEmbeddingFunction::Request(
+    const nlohmann::json& body) {
+  // Don't use SSL
+  httplib::Client client(m_BaseUrl);
+
+  httplib::Headers headers = {
+      {"Content-Type", "application/json;charset=utf-8"}};
+
+  httplib::Result res =
+      client.Post(m_Path, headers, body.dump(), "application/json");
+  if (res) {
+    if (res->status == httplib::OK_200) return nlohmann::json::parse(res->body);
+
+    throw EmbeddingProviderRequestException(res->body);
+  }
+
+  throw EmbeddingProviderConnectionException(httplib::to_string(res.error()));
+}
+
+}  // namespace chromadb


### PR DESCRIPTION
1. Make EmbeddingFunction::Request virtual to allow the class LocalOllamaEmbeddingFunction to override it with HTTP(httplib::Client) implementation.

2. In the constructor of the LocalOllamaEmbeddingFunction class, change the parameter apiKey to accept the local Ollama service address address. Modify the necessary data structures in the Generate member function.

== test case

std::shared_ptr<chromadb::LocalOllamaEmbeddingFunction> ef = 
    std::make_shared<chromadb::LocalOllamaEmbeddingFunction>(“localhost:11434”， “deepseek-r1:14b”);

    Collection collection = client->GetCollection("test_collection", ef);

    auto resp = client->Query(collection, { "This is a query document" }, {}, 3, { "metadatas", "documents", "embeddings", "distances" });

        for(auto& data:resp) {
            for(size_t i=0; i<data.ids.size(); i++) {
                printf("resp distance[%u] %lf\n", i, data.distances->at(i));
                printf("resp ids[%u] %s\n", i, data.ids[i].c_str());
                printf("resp doc[%u] %s\n", i, data.documents->at(i).c_str());
                
            }
        }

Outputs:

resp distance[0] 0.000959
resp ids[0] ID1
resp doc[0] This is a query document
resp distance[1] 1.277268
resp ids[1] ID2
resp doc[1] document2
resp distance[2] 1.283017
resp ids[2] ID3
resp doc[2] document3
